### PR TITLE
fix NPE/memory usage in computeRetainedSizes

### DIFF
--- a/src/main/java/abex/os/debug/HProfStripper.java
+++ b/src/main/java/abex/os/debug/HProfStripper.java
@@ -931,11 +931,18 @@ public class HProfStripper implements AutoCloseable
 			{
 				var rom = objects.get(i);
 				succs[i] = new int[rom.succs != null ? rom.succs.size() : 0];
+				int k = 0;
 				for (int j = 0; j < succs[i].length; ++j)
 				{
 					Integer node = objIdToNodeId.get(rom.succs.get(j));
-					assert node >= 0;
-					succs[i][j] = node;
+					if (node != null)
+					{
+						succs[i][k++] = node;
+					}
+				}
+				if (k != succs[i].length)
+				{
+					succs[i] = Arrays.copyOf(succs[i], k);
 				}
 			}
 

--- a/src/main/java/abex/os/debug/HProfStripper.java
+++ b/src/main/java/abex/os/debug/HProfStripper.java
@@ -944,9 +944,12 @@ public class HProfStripper implements AutoCloseable
 				{
 					succs[i] = Arrays.copyOf(succs[i], k);
 				}
+				rom.succs = null;
 			}
+			int rootNode = objIdToNodeId.get(-1L);
+			objIdToNodeId.clear();
 
-			var dom = new LengauerTarjan(objects.size(), objIdToNodeId.get(-1L), succs);
+			var dom = new LengauerTarjan(objects.size(), rootNode, succs);
 			int[] idom = dom.computeIdom();
 //			System.out.println("done computing immediate dominators");
 
@@ -954,11 +957,11 @@ public class HProfStripper implements AutoCloseable
 //			System.out.println("done computing dominator tree");
 
 			long[] retainedSize = new long[idom.length];
-			computeRetained(domTree, objIdToNodeId.get(-1L), retainedSize);
+			computeRetained(domTree, rootNode, retainedSize);
 //			System.out.println("done computing retained size");
 
 			int[] numObjects = new int[idom.length];
-			computeObjects(domTree, objIdToNodeId.get(-1L), numObjects);
+			computeObjects(domTree, rootNode, numObjects);
 //			System.out.println("done computing retained objects");
 
 			return new RetainedSizeResult(idom.length, classes, objects, retainedSize, numObjects);


### PR DESCRIPTION
```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because "node" is null
      at abex.os.debug.HProfStripper$RetainedSizeComputer.computeRetainedSizes(HProfStripper.java:938)
      at abex.os.debug.HProfStripper.runRetainedSizeComputer(HProfStripper.java:168)
      at abex.os.debug.RetainedSizeAnalyzer.showRetainedSizes(RetainedSizeAnalyzer.java:43)
      at abex.os.debug.RetainedSizeAnalyzer.main(RetainedSizeAnalyzer.java:27)
2026-06-20 12:30:37 BST [retained-size-analyzer] WARN  abex.os.debug.HeapDumpPanel - retained size analyzer exited with 1
```

Seems to be consistent on macOS, when I looked into what was dangling it seemed to be 467 `[Ljava/lang/Object`s

Without the memory fixes this OOMs with 2G, it was peaking at 2.7G on my machine, now it triggers a GC and finishes successfully

<img width="1050" height="697" alt="image" src="https://github.com/user-attachments/assets/2eb3ee40-b31b-48ca-b759-260c5c89a0a3" />
